### PR TITLE
Add respx-backed tests for responses and chat adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,12 @@ dependencies = [
   "openai==2.1.0",
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0",
+  "respx>=0.21",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["openai_monkey*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+@pytest.fixture
+def configure_adapter(request: pytest.FixtureRequest) -> Callable[..., Any]:
+    """Return a helper for reloading ``openai_monkey`` with a custom config."""
+
+    original_env: dict[str, Optional[str]] = {}
+
+    def _setenv(name: str, value: Optional[str]) -> None:
+        if name not in original_env:
+            original_env[name] = os.environ.get(name)
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    def _configure(
+        *,
+        base_url: str = "https://mock.local",
+        basic_token: str = "TEST_TOKEN",
+        path_map: Optional[Dict[str, str]] = None,
+        param_map: Optional[Dict[str, str]] = None,
+        drop_params: Optional[list[str]] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        disable_streaming: bool = False,
+    ) -> Any:
+        _setenv("OPENAI_BASIC_BASE_URL", base_url)
+        _setenv("OPENAI_BASIC_TOKEN", basic_token)
+
+        if path_map is not None:
+            _setenv("OPENAI_BASIC_PATH_MAP", json.dumps(path_map))
+        if param_map is not None:
+            _setenv("OPENAI_BASIC_PARAM_MAP", json.dumps(param_map))
+        if drop_params is not None:
+            _setenv("OPENAI_BASIC_DROP_PARAMS", json.dumps(drop_params))
+        if default_headers is not None:
+            _setenv("OPENAI_BASIC_HEADERS", json.dumps(default_headers))
+        _setenv("OPENAI_BASIC_DISABLE_STREAMING", "1" if disable_streaming else "0")
+
+        import openai_monkey
+
+        return importlib.reload(openai_monkey)
+
+    def _cleanup() -> None:
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if "openai_monkey" in sys.modules:
+            import openai_monkey
+
+            importlib.reload(openai_monkey)
+
+    request.addfinalizer(_cleanup)
+    return _configure

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+
+@pytest.fixture
+def chat_adapter(configure_adapter):
+    return configure_adapter(
+        path_map={
+            "/chat/completions": "/v1/chat",
+            "/chat/completions:stream": "/v1/chat-stream",
+        },
+        param_map={
+            "max_tokens": "max_output_tokens",
+            "temperature": "temp",
+        },
+        drop_params=["logprobs", "tool_choice"],
+        default_headers={"X-Test": "true"},
+    )
+
+
+def _json_payload(request: Any) -> dict[str, Any]:
+    body = request.content
+    return json.loads(body.decode("utf-8"))
+
+
+def _consume_sync_result(generator):
+    with pytest.raises(StopIteration) as exc_info:
+        next(generator)
+    return exc_info.value.value
+
+
+@respx.mock
+def test_chat_create_remaps_and_headers(chat_adapter):
+    # Arrange
+    client = chat_adapter.OpenAI()
+    route = respx.post("https://mock.local/v1/chat").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "id": "chat-123",
+                "model": "chat-model",
+                "result": {"text": "response"},
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        )
+    )
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+    # Act
+    result_iter = client.chat.completions.create(
+        model="chat-model",
+        messages=messages,
+        max_tokens=50,
+        tool_choice="none",
+        temperature=0.5,
+    )
+    result = _consume_sync_result(result_iter)
+
+    # Assert
+    assert route.called
+    request = route.calls[0].request
+    payload = _json_payload(request)
+    assert payload == {
+        "model": "chat-model",
+        "input": "SYSTEM: You are helpful.\nUSER: Hello\nASSISTANT:",
+        "temp": 0.5,
+        "max_output_tokens": 50,
+    }
+    assert request.headers["Authorization"] == "Basic TEST_TOKEN"
+    assert request.headers["X-Test"] == "true"
+    assert result == {
+        "id": "chat-123",
+        "model": "chat-model",
+        "output_text": "response",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+
+@respx.mock
+def test_chat_create_streaming_handles_malformed_lines(chat_adapter):
+    # Arrange
+    client = chat_adapter.OpenAI()
+    stream_body = (
+        b"data: {\"type\": \"delta\", \"text\": \"Hello\"}\n\n"
+        b"data: {\"text\": \" world\"}\n\n"
+        b"data: {\"type\": \"delta\", \"text\": "
+        b"\"ignored\"}\n\n"
+        b"data: {\"type\": \"done\"}\n\n"
+    )
+    route = respx.post("https://mock.local/v1/chat-stream").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            headers={"Content-Type": "text/event-stream"},
+            content=stream_body,
+        )
+    )
+
+    # Act
+    events = list(
+        client.chat.completions.create(
+            model="chat-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+        )
+    )
+
+    # Assert
+    assert route.called
+    assert events == [
+        {"type": "response.delta", "delta": {"output_text": "Hello"}},
+        {"type": "response.delta", "delta": {"output_text": " world"}},
+        {"type": "response.delta", "delta": {"output_text": "ignored"}},
+        {"type": "response.completed"},
+    ]
+
+
+@respx.mock
+def test_chat_create_raises_for_non_200(chat_adapter):
+    # Arrange
+    client = chat_adapter.OpenAI()
+    respx.post("https://mock.local/v1/chat").mock(
+        return_value=httpx.Response(status_code=500, json={"error": "bad"})
+    )
+
+    # Act / Assert
+    with pytest.raises(httpx.HTTPStatusError):
+        iterator = client.chat.completions.create(model="chat-model", messages=[])
+        next(iterator)
+
+
+@respx.mock
+def test_chat_create_normalizes_plain_text(chat_adapter):
+    # Arrange
+    client = chat_adapter.OpenAI()
+    respx.post("https://mock.local/v1/chat").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "id": "chat-456",
+                "model": "chat-model",
+                "text": "direct",
+                "usage": {},
+            },
+        )
+    )
+
+    # Act
+    result_iter = client.chat.completions.create(
+        model="chat-model",
+        messages=[{"role": "user", "content": "Hi"}],
+    )
+    result = _consume_sync_result(result_iter)
+
+    # Assert
+    assert result == {
+        "id": "chat-456",
+        "model": "chat-model",
+        "output_text": "direct",
+        "usage": {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": None,
+        },
+    }

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+
+@pytest.fixture
+def responses_adapter(configure_adapter):
+    return configure_adapter(
+        path_map={
+            "/responses": "/v1/resp",
+            "/responses:stream": "/v1/resp-stream",
+        },
+        param_map={
+            "max_tokens": "max_output_tokens",
+            "temperature": "temp",
+        },
+        drop_params=["logprobs", "tool_choice"],
+        default_headers={"X-Test": "true"},
+    )
+
+
+def _json_payload(request: Any) -> dict[str, Any]:
+    body = request.content
+    return json.loads(body.decode("utf-8"))
+
+
+@respx.mock
+def test_responses_create_remaps_and_headers(responses_adapter):
+    # Arrange
+    client = responses_adapter.OpenAI()
+    route = respx.post("https://mock.local/v1/resp").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "id": "resp-123",
+                "model": "m",
+                "result": {"text": "done"},
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            },
+        )
+    )
+
+    # Act
+    result = client.responses.create(
+        model="m",
+        input="hi",
+        max_tokens=5,
+        logprobs=2,
+        temperature=0.25,
+    )
+
+    # Assert
+    assert route.called
+    request = route.calls[0].request
+    payload = _json_payload(request)
+    assert payload == {
+        "model": "m",
+        "input": "hi",
+        "temp": 0.25,
+        "max_output_tokens": 5,
+    }
+    assert request.headers["Authorization"] == "Basic TEST_TOKEN"
+    assert request.headers["X-Test"] == "true"
+    assert result == {
+        "id": "resp-123",
+        "model": "m",
+        "output_text": "done",
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "total_tokens": 3,
+        },
+    }
+
+
+@respx.mock
+def test_responses_create_streaming_normalizes_lines(responses_adapter):
+    # Arrange
+    client = responses_adapter.OpenAI()
+    stream_body = (
+        b"data: {\"type\": \"delta\", \"text\": \"Hel\"}\n\n"
+        b"data: {\"type\": \"delta\", \"text\": \"lo\"}\n\n"
+        b"data: {\"type\": \"unknown\"}\n\n"
+        b"not-json\n\n"
+        b"\xff\n\n"
+        b"data: {\"type\": \"done\"}\n\n"
+    )
+    route = respx.post("https://mock.local/v1/resp-stream").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            headers={"Content-Type": "text/event-stream"},
+            content=stream_body,
+        )
+    )
+
+    # Act
+    events = list(
+        client.responses.create(
+            model="stream-model",
+            input="start",
+            stream=True,
+        )
+    )
+
+    # Assert
+    assert route.called
+    assert events == [
+        {"type": "response.delta", "delta": {"output_text": "Hel"}},
+        {"type": "response.delta", "delta": {"output_text": "lo"}},
+        {"type": "response.completed"},
+    ]
+
+
+@respx.mock
+def test_responses_create_raises_for_non_200(responses_adapter):
+    # Arrange
+    client = responses_adapter.OpenAI()
+    respx.post("https://mock.local/v1/resp").mock(
+        return_value=httpx.Response(status_code=500, json={"error": "boom"})
+    )
+
+    # Act / Assert
+    with pytest.raises(httpx.HTTPStatusError):
+        client.responses.create(model="m", input="hi")
+
+
+@respx.mock
+def test_responses_create_normalizes_missing_result(responses_adapter):
+    # Arrange
+    client = responses_adapter.OpenAI()
+    respx.post("https://mock.local/v1/resp").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "id": "resp-456",
+                "model": "m",
+                "choices": [
+                    {"message": {"content": "fallback"}},
+                ],
+                "usage": {"total_tokens": 7},
+            },
+        )
+    )
+
+    # Act
+    result = client.responses.create(model="m", input="hi")
+
+    # Assert
+    assert result == {
+        "id": "resp-456",
+        "model": "m",
+        "output_text": "fallback",
+        "usage": {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": 7,
+        },
+    }


### PR DESCRIPTION
## Summary
- add reusable configure_adapter fixture to reload openai_monkey with custom settings during tests
- cover responses.create sync/stream and error paths using respx to assert payloads and headers
- add chat.completions.create coverage for parameter mapping, streaming normalization, and error handling
- declare optional test dependencies for pytest and respx

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df24fd35388325b735b0d7a3fc5106