### PR TITLE
Add CLI tools for repository monkeyification and alias installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,26 @@ export OPENAI_BASIC_DISABLE_STREAMING=0
 ## Examples
 - `examples/minimal_app.py` demonstrates the default Basic flow.
 - `examples/bearer_app.py` shows how to call the adapter with Bearer tokens.
+
+## CLI helpers
+
+Installing the package exposes two helper commands:
+
+- `openai-monkey-ify`: Recursively rewrites `import openai` statements in a
+  repository so they load `openai_monkey` instead. Run it from the root of the
+  project you want to update:
+
+  ```bash
+  openai-monkey-ify  # defaults to the current directory
+  ```
+
+  Pass `--dry-run` to preview which files would change without editing them.
+
+- `openai-monkey-install-openai`: Creates a `.pth` alias so `import openai`
+  automatically resolves to `openai_monkey` in the active Python environment:
+
+  ```bash
+  openai-monkey-install-openai
+  ```
+
+  Use `--site-packages=/custom/path` to target a specific environment.

--- a/examples/minimal_app.py
+++ b/examples/minimal_app.py
@@ -1,7 +1,10 @@
 # examples/minimal_app.py (Basic-token mode)
 import os
+
 os.environ.setdefault("OPENAI_BASIC_BASE_URL", "https://internal.company.ai")
-os.environ.setdefault("OPENAI_BASIC_TOKEN", "abc.def.ghi")  # this is sent as: Authorization: Basic abc.def.ghi
+os.environ.setdefault(
+    "OPENAI_BASIC_TOKEN", "abc.def.ghi"
+)  # this is sent as: Authorization: Basic abc.def.ghi
 
 import openai_monkey as openai
 
@@ -12,7 +15,7 @@ print("SYNC:", r["output_text"])
 
 for ev in client.chat.completions.create(
     model="gpt-4o-mini",
-    messages=[{"role":"user","content":"stream a tiny poem no punctuation"}],
+    messages=[{"role": "user", "content": "stream a tiny poem no punctuation"}],
     stream=True,
 ):
     if ev.get("type") == "response.delta":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ test = [
   "respx>=0.21",
 ]
 
+[project.scripts]
+"openai-monkey-ify" = "openai_monkey.cli:monkeyify_main"
+"openai-monkey-install-openai" = "openai_monkey.cli:install_alias_main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["openai_monkey*"]

--- a/src/openai_monkey/cli.py
+++ b/src/openai_monkey/cli.py
@@ -1,0 +1,249 @@
+"""Command line utilities for the openai-monkey package."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+import sys
+import sysconfig
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _Replacement:
+    start: int
+    end: int
+    text: str
+
+
+def _line_offsets(source: str) -> list[int]:
+    """Return the starting offset for each line in *source*."""
+
+    offsets: list[int] = []
+    position = 0
+    for line in source.splitlines(keepends=True):
+        offsets.append(position)
+        position += len(line)
+    if not offsets:
+        offsets.append(0)
+    return offsets
+
+
+def _absolute_offset(offsets: Sequence[int], lineno: int, col: int) -> int:
+    """Translate a line/column pair into an absolute character offset."""
+
+    return offsets[lineno - 1] + col
+
+
+def _transform_import(node: ast.Import) -> tuple[ast.Import, bool]:
+    """Return a transformed import node and whether it changed."""
+
+    new_aliases: list[ast.alias] = []
+    changed = False
+    for alias in node.names:
+        if alias.name == "openai":
+            new_aliases.append(
+                ast.alias(name="openai_monkey", asname=alias.asname or "openai")
+            )
+            changed = True
+        else:
+            new_aliases.append(alias)
+    return ast.Import(names=new_aliases), changed
+
+
+def _transform_import_from(node: ast.ImportFrom) -> tuple[ast.ImportFrom, bool]:
+    """Return a transformed import-from node and whether it changed."""
+
+    if not node.module or node.level != 0:
+        return node, False
+
+    if node.module == "openai":
+        return ast.ImportFrom(module="openai_monkey", names=node.names, level=0), True
+
+    if node.module.startswith("openai."):
+        new_module = "openai_monkey" + node.module[len("openai") :]
+        return ast.ImportFrom(module=new_module, names=node.names, level=0), True
+
+    return node, False
+
+
+def _rewrite_source(source: str) -> tuple[str, bool]:
+    """Rewrite import statements in *source* to reference ``openai_monkey``."""
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:  # pragma: no cover - defensive guard
+        LOGGER.warning("Skipping file with syntax error: %s", exc)
+        return source, False
+
+    replacements: list[_Replacement] = []
+    offsets = _line_offsets(source)
+
+    for node in ast.walk(tree):
+        replacement_node: ast.AST
+        if isinstance(node, ast.Import):
+            replacement_node, changed = _transform_import(node)
+            if not changed:
+                continue
+        elif isinstance(node, ast.ImportFrom):
+            replacement_node, changed = _transform_import_from(node)
+            if not changed:
+                continue
+        else:
+            continue
+
+        if node.end_lineno is None or node.end_col_offset is None:
+            continue
+
+        start = _absolute_offset(offsets, node.lineno, node.col_offset)
+        end = _absolute_offset(offsets, node.end_lineno, node.end_col_offset)
+        replacements.append(
+            _Replacement(start=start, end=end, text=ast.unparse(replacement_node))
+        )
+
+    if not replacements:
+        return source, False
+
+    new_source = source
+    for replacement in sorted(replacements, key=lambda repl: repl.start, reverse=True):
+        new_source = (
+            new_source[: replacement.start]
+            + replacement.text
+            + new_source[replacement.end :]
+        )
+
+    return new_source, True
+
+
+def monkeyify_repository(path: Path, *, dry_run: bool = False) -> list[Path]:
+    """Rewrite ``openai`` imports under *path* to use ``openai_monkey``.
+
+    Args:
+        path: Base directory that will be searched recursively.
+        dry_run: When ``True`` no files are modified.
+
+    Returns:
+        A sorted list of files that would be (or were) rewritten.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"Repository path does not exist: {path}")
+    if not path.is_dir():
+        raise NotADirectoryError(f"Repository path must be a directory: {path}")
+
+    changed: list[Path] = []
+    for python_file in sorted(path.rglob("*.py")):
+        source = python_file.read_text(encoding="utf-8")
+        rewritten, modified = _rewrite_source(source)
+        if not modified:
+            continue
+        changed.append(python_file)
+        if dry_run:
+            continue
+        python_file.write_text(rewritten, encoding="utf-8")
+
+    return changed
+
+
+def _create_alias_file(site_packages: Path) -> Path:
+    """Create a ``.pth`` alias that exposes ``openai_monkey`` as ``openai``."""
+
+    site_packages.mkdir(parents=True, exist_ok=True)
+    alias_path = site_packages / "openai_monkey_as_openai.pth"
+    alias_contents = (
+        "import importlib, sys; "
+        "sys.modules.setdefault('openai', importlib.import_module('openai_monkey'))\n"
+    )
+    alias_path.write_text(alias_contents, encoding="utf-8")
+    return alias_path
+
+
+def install_alias(*, site_packages: Path | None = None) -> Path:
+    """Install the ``openai`` alias for ``openai_monkey`` in ``site-packages``."""
+
+    try:
+        __import__("openai_monkey")
+    except ImportError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError("openai_monkey must be installed before aliasing") from exc
+
+    if site_packages is None:
+        site_packages = Path(sysconfig.get_path("purelib"))
+
+    return _create_alias_file(site_packages)
+
+
+def monkeyify_main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point that rewrites ``openai`` imports in a repository."""
+
+    parser = argparse.ArgumentParser(
+        prog="openai-monkey-ify",
+        description="Rewrite openai imports in a repository to use openai_monkey.",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        type=Path,
+        help="Repository root to rewrite (defaults to current working directory).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which files would change without modifying them.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        changed = monkeyify_repository(args.path.resolve(), dry_run=args.dry_run)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        parser.error(str(exc))
+        return 2  # pragma: no cover - unreachable because parser.error exits
+
+    if changed:
+        for file_path in changed:
+            print(file_path)
+        message = "Updated" if not args.dry_run else "Would update"
+        print(f"{message} {len(changed)} file(s).")
+    else:
+        message = (
+            "No files needed changes." if not args.dry_run else "No files would change."
+        )
+        print(message)
+
+    return 0
+
+
+def install_alias_main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point that installs the ``openai`` alias for ``openai_monkey``."""
+
+    parser = argparse.ArgumentParser(
+        prog="openai-monkey-install-openai",
+        description="Install a site-packages alias so 'import openai' loads openai_monkey.",
+    )
+    parser.add_argument(
+        "--site-packages",
+        type=Path,
+        help="Override the target site-packages directory (primarily for testing).",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        alias_path = install_alias(site_packages=args.site_packages)
+    except RuntimeError as exc:
+        parser.error(str(exc))
+        return 2  # pragma: no cover - parser.error exits
+
+    print(f"Alias installed at {alias_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution guard
+    sys.exit(monkeyify_main())

--- a/src/openai_monkey/config.py
+++ b/src/openai_monkey/config.py
@@ -70,14 +70,16 @@ def load_config() -> dict[str, Any]:
         _load_json_env("OPENAI_BASIC_DROP_PARAMS", ["logprobs", "tool_choice"])
     )
     extra_allow = set(_load_json_env("OPENAI_BASIC_EXTRA_ALLOW", ["safety_profile"]))
-    model_routes = _load_json_env("OPENAI_BASIC_MODEL_ROUTES", {})
+    model_routes: dict[str, dict[str, Any]] = _load_json_env(
+        "OPENAI_BASIC_MODEL_ROUTES", {}
+    )
     disable_streaming = os.getenv("OPENAI_BASIC_DISABLE_STREAMING", "0") not in (
         "",
         "0",
         "false",
         "False",
     )
-    default_headers = _load_json_env("OPENAI_BASIC_HEADERS", {})
+    default_headers: dict[str, str] = _load_json_env("OPENAI_BASIC_HEADERS", {})
 
     return {
         "auth_type": auth_type,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
-import respx
+import respx  # type: ignore[import]
 
 
 @pytest.fixture(params=["basic", "bearer"])
@@ -26,9 +26,7 @@ def chat_adapter(configure_adapter, request):
         token=token,
         auth_type=auth_type,
     )
-    expected_header = (
-        f"Basic {token}" if auth_type == "basic" else f"Bearer {token}"
-    )
+    expected_header = f"Basic {token}" if auth_type == "basic" else f"Bearer {token}"
     return module, expected_header
 
 
@@ -55,7 +53,11 @@ def test_chat_create_remaps_and_headers(chat_adapter):
                 "id": "chat-123",
                 "model": "chat-model",
                 "result": {"text": "response"},
-                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
             },
         )
     )
@@ -104,11 +106,11 @@ def test_chat_create_streaming_handles_malformed_lines(chat_adapter):
     module, expected_header = chat_adapter
     client = module.OpenAI()
     stream_body = (
-        b"data: {\"type\": \"delta\", \"text\": \"Hello\"}\n\n"
-        b"data: {\"text\": \" world\"}\n\n"
-        b"data: {\"type\": \"delta\", \"text\": "
-        b"\"ignored\"}\n\n"
-        b"data: {\"type\": \"done\"}\n\n"
+        b'data: {"type": "delta", "text": "Hello"}\n\n'
+        b'data: {"text": " world"}\n\n'
+        b'data: {"type": "delta", "text": '
+        b'"ignored"}\n\n'
+        b'data: {"type": "done"}\n\n'
     )
     route = respx.post("https://mock.local/v1/chat-stream").mock(
         return_value=httpx.Response(

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,0 +1,79 @@
+"""Tests for the command-line utilities shipped with openai-monkey."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+from openai_monkey import cli
+
+
+def _write(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+
+
+def test_monkeyify_repository_rewrites_common_imports(tmp_path: Path) -> None:
+    """The repository rewriter should cover a variety of import styles."""
+
+    source = tmp_path / "sample.py"
+    _write(
+        source,
+        "\n".join(
+            [
+                "import os",
+                "import openai",
+                "import openai as openai_client",
+                "import openai, sys",
+                "from openai import OpenAI, AsyncOpenAI",
+                "from openai.types import ChatCompletion",
+                "",
+                "print(OpenAI, AsyncOpenAI, openai_client, os, sys)",
+            ]
+        )
+        + "\n",
+    )
+
+    changed = cli.monkeyify_repository(tmp_path)
+
+    assert changed == [source]
+    rewritten = source.read_text(encoding="utf-8")
+    assert "import openai_monkey as openai" in rewritten
+    assert "import openai_monkey as openai_client" in rewritten
+    assert "import openai_monkey as openai, sys" in rewritten
+    assert "from openai_monkey import OpenAI, AsyncOpenAI" in rewritten
+    assert "from openai_monkey.types import ChatCompletion" in rewritten
+
+
+def test_monkeyify_repository_supports_dry_run(tmp_path: Path) -> None:
+    """When dry_run is enabled, files are not modified."""
+
+    source = tmp_path / "module.py"
+    original = "import openai\n"
+    _write(source, original)
+
+    changed = cli.monkeyify_repository(tmp_path, dry_run=True)
+
+    assert changed == [source]
+    assert source.read_text(encoding="utf-8") == original
+
+
+def test_install_alias_creates_pth_file(tmp_path: Path) -> None:
+    """The alias installer should produce an executable .pth file."""
+
+    alias_path = cli.install_alias(site_packages=tmp_path)
+
+    assert alias_path.exists()
+    contents = alias_path.read_text(encoding="utf-8")
+    assert "import importlib, sys" in contents
+
+    previous = sys.modules.get("openai")
+    try:
+        sys.modules.pop("openai", None)
+        exec(contents, {"sys": sys, "importlib": importlib})
+        assert sys.modules["openai"] is importlib.import_module("openai_monkey")
+    finally:
+        if previous is None:
+            sys.modules.pop("openai", None)
+        else:
+            sys.modules["openai"] = previous

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
-import respx
+import respx  # type: ignore[import]
 
 
 @pytest.fixture(params=["basic", "bearer"])
@@ -26,9 +26,7 @@ def responses_adapter(configure_adapter, request):
         token=token,
         auth_type=auth_type,
     )
-    expected_header = (
-        f"Basic {token}" if auth_type == "basic" else f"Bearer {token}"
-    )
+    expected_header = f"Basic {token}" if auth_type == "basic" else f"Bearer {token}"
     return module, expected_header
 
 
@@ -49,7 +47,11 @@ def test_responses_create_remaps_and_headers(responses_adapter):
                 "id": "resp-123",
                 "model": "m",
                 "result": {"text": "done"},
-                "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 2,
+                    "total_tokens": 3,
+                },
             },
         )
     )
@@ -93,12 +95,12 @@ def test_responses_create_streaming_normalizes_lines(responses_adapter):
     module, expected_header = responses_adapter
     client = module.OpenAI()
     stream_body = (
-        b"data: {\"type\": \"delta\", \"text\": \"Hel\"}\n\n"
-        b"data: {\"type\": \"delta\", \"text\": \"lo\"}\n\n"
-        b"data: {\"type\": \"unknown\"}\n\n"
+        b'data: {"type": "delta", "text": "Hel"}\n\n'
+        b'data: {"type": "delta", "text": "lo"}\n\n'
+        b'data: {"type": "unknown"}\n\n'
         b"not-json\n\n"
         b"\xff\n\n"
-        b"data: {\"type\": \"done\"}\n\n"
+        b'data: {"type": "done"}\n\n'
     )
     route = respx.post("https://mock.local/v1/resp-stream").mock(
         return_value=httpx.Response(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,16 +3,20 @@ import os
 
 import httpx
 import pytest
-import respx
+import respx  # type: ignore[import]
+
 os.environ.setdefault("OPENAI_BASIC_BASE_URL", "https://internal.company.ai")
 os.environ.setdefault("OPENAI_BASIC_TOKEN", "TEST_TOKEN")
 
 import openai_monkey as openai
 
+
 @respx.mock
 def test_sync_ok():
     respx.post("https://internal.company.ai/api/generate").mock(
-        return_value=httpx.Response(200, json={"result":{"text":"ok"}, "usage":{"total_tokens":1}})
+        return_value=httpx.Response(
+            200, json={"result": {"text": "ok"}, "usage": {"total_tokens": 1}}
+        )
     )
     r = openai.OpenAI().responses.create(model="m", input="hi", max_tokens=5)
     assert r["output_text"] == "ok"


### PR DESCRIPTION
## Summary
- add a CLI module with commands to rewrite openai imports and install an openai alias
- expose the new scripts via entry points and document their usage in the README
- harden module aliasing support and cover the new flows with automated tests

## Testing
- ruff check .
- black .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2a98b3848325b2e7a2a1e7bee24c