### PR TITLE
Add CI workflow to run pytest on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs pytest when pull requests are opened
- install the project with its test extra before executing the suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2cf7a3148325bbbf702a0a3832be