### PR TITLE
Harden configuration parsing and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Minimal (Basic auth, default):
 export OPENAI_AUTH_TYPE="basic"
 export OPENAI_BASE_URL="https://internal.company.ai"
 export OPENAI_TOKEN="$YOUR_BASIC_TOKEN"   # sends: Authorization: Basic $YOUR_BASIC_TOKEN
+# The token must be configured; the adapter refuses to start with placeholder values.
 ```
 
 Bearer support:

--- a/src/openai_monkey/__init__.py
+++ b/src/openai_monkey/__init__.py
@@ -6,27 +6,27 @@ import sys
 import types as _types
 
 from .adapter import apply_adapter_patch
-from .config import load_config
+from .config import AdapterConfig, load_config
 
-CFG = load_config()
+CFG: AdapterConfig = load_config()
 
 _SUPPORTED_AUTH_TYPES = {"basic", "bearer"}
-if CFG["auth_type"] not in _SUPPORTED_AUTH_TYPES:
+if CFG.auth_type not in _SUPPORTED_AUTH_TYPES:
     raise ValueError(
-        f"Unsupported OPENAI_AUTH_TYPE '{CFG['auth_type']}'. Supported types: {sorted(_SUPPORTED_AUTH_TYPES)}"
+        f"Unsupported OPENAI_AUTH_TYPE '{CFG.auth_type}'. Supported types: {sorted(_SUPPORTED_AUTH_TYPES)}"
     )
 
 apply_adapter_patch(
-    base_url=CFG["base_url"],
-    auth_type=CFG["auth_type"],
-    token=CFG["token"],
-    path_map=CFG["path_map"],
-    param_map=CFG["param_map"],
-    drop_params=CFG["drop_params"],
-    extra_allow=CFG["extra_allow"],
-    model_routes=CFG["model_routes"],
-    disable_streaming=CFG["disable_streaming"],
-    default_headers=CFG["default_headers"],
+    base_url=CFG.base_url,
+    auth_type=CFG.auth_type,
+    token=CFG.token,
+    path_map=CFG.path_map,
+    param_map=CFG.param_map,
+    drop_params=CFG.drop_params,
+    extra_allow=CFG.extra_allow,
+    model_routes=CFG.model_routes,
+    disable_streaming=CFG.disable_streaming,
+    default_headers=CFG.default_headers,
 )
 
 _openai = importlib.import_module("openai")  # patched

--- a/src/openai_monkey/config.py
+++ b/src/openai_monkey/config.py
@@ -2,94 +2,218 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, TypeVar
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
 
 
-_T = TypeVar("_T")
+def _load_json_env(name: str, *, default: Any) -> Any:
+    """Return the parsed JSON value for ``name``.
 
+    Args:
+        name: Environment variable that potentially stores JSON encoded data.
+        default: Value returned when the variable is not defined.
 
-def _load_json_env(name: str, default: _T) -> _T:
-    """Load an environment variable as JSON, falling back to ``default``."""
+    Raises:
+        ValueError: If the variable is defined but does not contain valid JSON.
+    """
 
     raw = os.getenv(name)
-    if not raw:
+    if raw is None or raw.strip() == "":
         return default
     try:
         return json.loads(raw)
-    except Exception:
-        return default
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive, re-raised
+        raise ValueError(
+            f"Environment variable {name} must contain valid JSON: {exc}"
+        ) from exc
 
 
 def _pick_env(*names: str, default: str) -> str:
-    """Return the first set environment variable among ``names`` or ``default``."""
+    """Return the first defined environment variable among ``names``.
+
+    Leading and trailing whitespace is stripped from the returned value.  When
+    no variables are defined ``default`` is returned.
+    """
 
     for name in names:
         value = os.getenv(name)
-        if value:
-            return value
+        if value is not None:
+            stripped = value.strip()
+            if stripped:
+                return stripped
     return default
 
 
-def load_config() -> dict[str, Any]:
+def _ensure_non_empty(value: str, *, name: str) -> str:
+    """Validate that ``value`` is a non-empty string."""
+
+    if not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _normalize_bool_env(name: str, *, default: bool) -> bool:
+    """Convert an environment variable into a strict boolean."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    raise ValueError(
+        f"{name} must be a boolean flag (accepted values: 1/0/true/false/yes/no/on/off)"
+    )
+
+
+def _ensure_str_mapping(name: str, value: Any) -> dict[str, str]:
+    """Ensure ``value`` is a mapping of strings to strings."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must decode to an object mapping strings to strings")
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise ValueError(f"{name} keys and values must be strings")
+        result[key] = item
+    return result
+
+
+def _ensure_str_set(name: str, value: Any, *, default: Iterable[str]) -> set[str]:
+    """Ensure ``value`` is a collection of strings."""
+
+    if value is None:
+        return set(default)
+    if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{name} must decode to an array of strings")
+    items: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{name} entries must be strings")
+        items.add(item)
+    return items
+
+
+def _ensure_model_routes(name: str, value: Any) -> dict[str, dict[str, Any]]:
+    """Ensure ``value`` is a mapping of route patterns to configuration dictionaries."""
+
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must decode to an object mapping strings to objects")
+    normalized: dict[str, dict[str, Any]] = {}
+    for pattern, cfg in value.items():
+        if not isinstance(pattern, str):
+            raise ValueError(f"{name} keys must be strings")
+        if not isinstance(cfg, Mapping):
+            raise ValueError(f"{name} entries must be objects")
+        normalized[pattern] = dict(cfg)
+    return normalized
+
+
+@dataclass(frozen=True)
+class AdapterConfig:
+    """Runtime configuration for the OpenAI adapter."""
+
+    auth_type: str
+    base_url: str
+    token: str
+    path_map: dict[str, str]
+    param_map: dict[str, str]
+    drop_params: set[str]
+    extra_allow: set[str]
+    model_routes: dict[str, dict[str, Any]]
+    disable_streaming: bool
+    default_headers: dict[str, str]
+
+
+def load_config() -> AdapterConfig:
     """Load adapter configuration from environment variables."""
 
     auth_type = os.getenv("OPENAI_AUTH_TYPE", "basic").strip().lower() or "basic"
 
-    base_url = _pick_env(
-        "OPENAI_BASE_URL",
-        "OPENAI_BASIC_BASE_URL",
-        default="https://internal.company.ai",
+    base_url = _ensure_non_empty(
+        _pick_env(
+            "OPENAI_BASE_URL",
+            "OPENAI_BASIC_BASE_URL",
+            default="https://internal.company.ai",
+        ),
+        name="OPENAI_BASE_URL",
     )
 
-    token = _pick_env(
-        "OPENAI_TOKEN",
-        "OPENAI_BEARER_TOKEN",
-        "OPENAI_BASIC_TOKEN",
-        "OPENAI_API_KEY",
-        "OPENAI_KEY",
-        default="REPLACE_ME",
+    token = _ensure_non_empty(
+        _pick_env(
+            "OPENAI_TOKEN",
+            "OPENAI_BEARER_TOKEN",
+            "OPENAI_BASIC_TOKEN",
+            "OPENAI_API_KEY",
+            "OPENAI_KEY",
+            default="",
+        ),
+        name="OPENAI_TOKEN",
     )
 
-    path_map = _load_json_env(
+    if token == "REPLACE_ME":
+        raise ValueError("OPENAI_TOKEN must be configured with a real credential")
+
+    raw_path_map = _load_json_env(
         "OPENAI_BASIC_PATH_MAP",
-        {
+        default={
             "/responses": "/api/generate",
             "/responses:stream": "/api/stream",
             "/chat/completions": "/api/generate",
             "/chat/completions:stream": "/api/stream",
         },
     )
-    param_map = _load_json_env(
+    path_map = _ensure_str_mapping("OPENAI_BASIC_PATH_MAP", raw_path_map)
+
+    raw_param_map = _load_json_env(
         "OPENAI_BASIC_PARAM_MAP",
-        {
+        default={
             "max_tokens": "max_output_tokens",
             "top_p": "nucleus",
         },
     )
-    drop_params = set(
-        _load_json_env("OPENAI_BASIC_DROP_PARAMS", ["logprobs", "tool_choice"])
-    )
-    extra_allow = set(_load_json_env("OPENAI_BASIC_EXTRA_ALLOW", ["safety_profile"]))
-    model_routes: dict[str, dict[str, Any]] = _load_json_env(
-        "OPENAI_BASIC_MODEL_ROUTES", {}
-    )
-    disable_streaming = os.getenv("OPENAI_BASIC_DISABLE_STREAMING", "0") not in (
-        "",
-        "0",
-        "false",
-        "False",
-    )
-    default_headers: dict[str, str] = _load_json_env("OPENAI_BASIC_HEADERS", {})
+    param_map = _ensure_str_mapping("OPENAI_BASIC_PARAM_MAP", raw_param_map)
 
-    return {
-        "auth_type": auth_type,
-        "base_url": base_url,
-        "token": token,
-        "path_map": path_map,
-        "param_map": param_map,
-        "drop_params": drop_params,
-        "extra_allow": extra_allow,
-        "model_routes": model_routes,
-        "disable_streaming": disable_streaming,
-        "default_headers": default_headers,
-    }
+    drop_params = _ensure_str_set(
+        "OPENAI_BASIC_DROP_PARAMS",
+        _load_json_env("OPENAI_BASIC_DROP_PARAMS", default=["logprobs", "tool_choice"]),
+        default=["logprobs", "tool_choice"],
+    )
+
+    extra_allow = _ensure_str_set(
+        "OPENAI_BASIC_EXTRA_ALLOW",
+        _load_json_env("OPENAI_BASIC_EXTRA_ALLOW", default=["safety_profile"]),
+        default=["safety_profile"],
+    )
+
+    model_routes = _ensure_model_routes(
+        "OPENAI_BASIC_MODEL_ROUTES",
+        _load_json_env("OPENAI_BASIC_MODEL_ROUTES", default={}),
+    )
+
+    disable_streaming = _normalize_bool_env(
+        "OPENAI_BASIC_DISABLE_STREAMING", default=False
+    )
+
+    default_headers = _ensure_str_mapping(
+        "OPENAI_BASIC_HEADERS",
+        _load_json_env("OPENAI_BASIC_HEADERS", default={}),
+    )
+
+    return AdapterConfig(
+        auth_type=auth_type,
+        base_url=base_url,
+        token=token,
+        path_map=path_map,
+        param_map=param_map,
+        drop_params=drop_params,
+        extra_allow=extra_allow,
+        model_routes=model_routes,
+        disable_streaming=disable_streaming,
+        default_headers=default_headers,
+    )

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 from pathlib import Path
+
+os.environ.setdefault("OPENAI_BASE_URL", "https://internal.company.ai")
+os.environ.setdefault("OPENAI_TOKEN", "TEST_TOKEN")
 
 from openai_monkey import cli
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+import pytest
+
+from openai_monkey import config as config_module
+
+
+def _reload_config_env(**env: Any) -> Any:
+    """Reload the configuration module with the provided environment values."""
+
+    previous: dict[str, str | None] = {}
+    for key, value in env.items():
+        previous[key] = os.environ.get(key)
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        importlib.reload(config_module)
+        return config_module.load_config()
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        importlib.reload(config_module)
+
+
+def _baseline_env() -> dict[str, str]:
+    """Return a minimal valid configuration for testing."""
+
+    return {
+        "OPENAI_BASE_URL": "https://secure.local",
+        "OPENAI_TOKEN": "super-secret",
+    }
+
+
+def test_load_config_rejects_invalid_disable_streaming_flag() -> None:
+    """Non-boolean values for the streaming flag should raise an error."""
+
+    env = _baseline_env()
+    env["OPENAI_BASIC_DISABLE_STREAMING"] = "maybe"
+
+    with pytest.raises(ValueError, match="boolean flag"):
+        _reload_config_env(**env)
+
+
+def test_load_config_rejects_malformed_json_payload() -> None:
+    """Invalid JSON configuration payloads should raise informative errors."""
+
+    env = _baseline_env()
+    env["OPENAI_BASIC_HEADERS"] = "not-json"
+
+    with pytest.raises(ValueError, match="valid JSON"):
+        _reload_config_env(**env)
+
+
+def test_load_config_rejects_non_string_headers() -> None:
+    """Mappings that are not string to string should be rejected."""
+
+    env = _baseline_env()
+    env["OPENAI_BASIC_HEADERS"] = '{"X-Test": 1}'
+
+    with pytest.raises(ValueError, match="strings"):
+        _reload_config_env(**env)
+
+
+def test_load_config_rejects_placeholder_token() -> None:
+    """Placeholder tokens should not be accepted."""
+
+    env = _baseline_env()
+    env["OPENAI_TOKEN"] = "REPLACE_ME"
+
+    with pytest.raises(ValueError, match="real credential"):
+        _reload_config_env(**env)
+
+
+def test_load_config_accepts_valid_payload() -> None:
+    """A complete, valid configuration should be returned as a dataclass."""
+
+    env = _baseline_env()
+    env.update(
+        {
+            "OPENAI_AUTH_TYPE": "Bearer",
+            "OPENAI_BASIC_HEADERS": '{"X-Test": "true"}',
+            "OPENAI_BASIC_DROP_PARAMS": '["a", "b"]',
+            "OPENAI_BASIC_EXTRA_ALLOW": '["safety"]',
+            "OPENAI_BASIC_DISABLE_STREAMING": "true",
+        }
+    )
+
+    config = _reload_config_env(**env)
+
+    assert config.auth_type == "bearer"
+    assert config.base_url == "https://secure.local"
+    assert config.token == "super-secret"
+    assert config.default_headers == {"X-Test": "true"}
+    assert config.drop_params == {"a", "b"}
+    assert config.extra_allow == {"safety"}
+    assert config.disable_streaming is True


### PR DESCRIPTION
## Summary
- introduce a typed AdapterConfig and strict environment validation for adapter settings
- update the package initialisation to use the dataclass and document the real-token requirement
- add targeted configuration tests and ensure CLI tooling tests seed the required environment

## Testing
- python -m black src/openai_monkey/config.py tests/test_config.py tests/test_cli_tools.py
- ruff check
- mypy src/openai_monkey
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df361b3bb88325b23db2233818e4e8