### PR TITLE
Fix macOS artifact uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  upload-macos-artifacts:
+    name: Upload macOS release bundles
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload macOS build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: pastrami-macos
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/macos/pastrami.app
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/pastrami_0.1.0_universal.dmg
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a release workflow that uploads the macOS app bundle and disk image produced by the pastrami build

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df3705304c8325a0e6aefde4d87e59