### PR TITLE
Add documentation for adapter monkeypatch

### DIFF
--- a/src/openai_monkey/__init__.py
+++ b/src/openai_monkey/__init__.py
@@ -1,3 +1,11 @@
+"""Load the OpenAI compatibility layer and expose patched client classes.
+
+Importing :mod:`openai_monkey` reads adapter configuration from the environment
+and immediately monkeypatches the installed ``openai`` package.  Once the patch
+is applied, applications can continue to ``import openai`` while transparently
+communicating with the internal provider configured by :func:`load_config`.
+"""
+
 from __future__ import annotations
 
 import importlib

--- a/src/openai_monkey/adapter.py
+++ b/src/openai_monkey/adapter.py
@@ -1,3 +1,12 @@
+"""Runtime adapter that monkeypatches the official ``openai`` client.
+
+The :func:`apply_adapter_patch` function swaps the HTTP layer used by the
+official `openai` package so requests are transparently redirected to an
+internal endpoint.  The helpers defined within the module focus on translating
+between the public OpenAI API surface and the internal provider so callers do
+not need to change their application code.
+"""
+
 from __future__ import annotations
 
 import json
@@ -18,11 +27,63 @@ def apply_adapter_patch(
     model_routes: Dict[str, Dict[str, Any]] | None,
     disable_streaming: bool,
     default_headers: Dict[str, str] | None,
-) -> bool:
+    ) -> bool:
+    """Patch ``openai`` to issue requests through the configured adapter.
+
+    The patch works by replacing the ``OpenAI``/``AsyncOpenAI`` client classes
+    and selected resource methods with thin wrappers.  These wrappers translate
+    keyword arguments, map request bodies to the internal schema, and route
+    calls to the HTTP endpoints described by ``path_map`` and
+    ``model_routes``.
+
+    Args:
+        base_url: Fully qualified base URL for the internal provider.
+        auth_type: Authentication scheme used to build the ``Authorization``
+            header (``"basic"`` or ``"bearer"``).
+        token: Credential associated with ``auth_type``.
+        path_map: Mapping of OpenAI REST paths to internal paths.  Streaming
+            variants are suffixed with ``":stream"``.
+        param_map: Mapping of keyword parameters that must be renamed when
+            forwarding to the internal API.
+        drop_params: Parameters that should be removed before forwarding the
+            request.
+        extra_allow: Parameters that should bypass validation when interacting
+            with the internal API.
+        model_routes: Overrides for particular model identifiers.  Regular
+            expression keys can redirect traffic to custom paths.
+        disable_streaming: When ``True`` the adapter converts streaming requests
+            into synchronous calls.
+        default_headers: Additional HTTP headers that should be attached to
+            outgoing requests.
+
+    Returns:
+        ``True`` when the patch applied successfully.
+
+    Examples:
+        >>> apply_adapter_patch(
+        ...     base_url="https://internal.example",  # doctest: +SKIP
+        ...     auth_type="basic",
+        ...     token="token",
+        ...     path_map={"/responses": "/responses"},
+        ...     param_map={},
+        ...     drop_params=set(),
+        ...     extra_allow=set(),
+        ...     model_routes={},
+        ...     disable_streaming=False,
+        ...     default_headers=None,
+        ... )
+        True
+    """
     import httpx
     import openai
 
+    # Helper utilities -----------------------------------------------------
+    # The following closures operate on the configuration above to bridge the
+    # gap between the public ``openai`` API and the internal provider.
+
     def _mk_headers():
+        """Construct the HTTP headers used for every proxied request."""
+
         scheme = "basic" if not auth_type else auth_type.lower()
         if scheme == "basic":
             value = f"Basic {token}"
@@ -36,6 +97,8 @@ def apply_adapter_patch(
         return h
 
     def _rewrite_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Rewrite keyword arguments so the internal API understands them."""
+
         out: Dict[str, Any] = {}
         for k, v in kwargs.items():
             if k in drop_params:
@@ -45,6 +108,8 @@ def apply_adapter_patch(
         return out
 
     def _messages_to_prompt(messages):
+        """Flatten chat messages into the prompt format required internally."""
+
         lines = []
         for m in messages:
             role = m.get("role", "user")
@@ -54,6 +119,8 @@ def apply_adapter_patch(
         return "\n".join(lines)
 
     def _build_payload(model: str, content: Any, **kwargs) -> Dict[str, Any]:
+        """Compose the JSON body expected by the internal inference endpoint."""
+
         pay: Dict[str, Any] = {"model": model, "input": content}
         if "temperature" in kwargs:
             pay[param_map.get("temperature", "temperature")] = kwargs["temperature"]
@@ -64,6 +131,8 @@ def apply_adapter_patch(
         return pay
 
     def _normalize_sync(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize synchronous responses to mimic ``openai`` semantics."""
+
         result = data.get("result") or {}
         text = (
             result.get("text")
@@ -88,6 +157,8 @@ def apply_adapter_patch(
         }
 
     def _normalize_stream_line(line: bytes | str):
+        """Translate streaming payloads into OpenAI-compatible events."""
+
         if not line:
             return None
         if isinstance(line, bytes):
@@ -117,6 +188,8 @@ def apply_adapter_patch(
         return None
 
     def _route_for(model: str, base_path: str, *, stream: bool) -> str:
+        """Choose the target path for *model* optionally considering streaming."""
+
         if model_routes:
             for pat, cfg in model_routes.items():
                 try:
@@ -129,11 +202,16 @@ def apply_adapter_patch(
         key = f"{base_path}:stream" if stream else base_path
         return path_map.get(key, base_path)
 
-    # Patch constructors
+    # Patch constructors ----------------------------------------------------
+    # We wrap the official ``OpenAI`` client classes so they default to using
+    # our HTTP clients.  This ensures every consumer—synchronous or
+    # asynchronous—transparently communicates with the internal base URL.
     _OrigOpenAI = cast(type[Any], openai.OpenAI)
     _OrigAsyncOpenAI = cast(type[Any] | None, getattr(openai, "AsyncOpenAI", None))
 
     def _mk_httpx_client():
+        """Create the default ``httpx.Client`` used for patched calls."""
+
         return httpx.Client(
             base_url=base_url.rstrip("/"),
             headers=_mk_headers(),
@@ -142,6 +220,8 @@ def apply_adapter_patch(
 
     class PatchedOpenAI(_OrigOpenAI):  # type: ignore[misc, valid-type]
         def __init__(self, *args, **kwargs):
+            """Initialize the patched client with adapter-aware defaults."""
+
             kwargs.setdefault("base_url", base_url.rstrip("/"))
             kwargs.setdefault("api_key", "x")  # ignored
             if "http_client" not in kwargs or kwargs["http_client"] is None:
@@ -154,6 +234,8 @@ def apply_adapter_patch(
 
         class _PatchedAsyncOpenAI(_OrigAsyncOpenAI):  # type: ignore[misc, valid-type]
             def __init__(self, *args, **kwargs):
+                """Initialize the async client to communicate via the adapter."""
+
                 kwargs.setdefault("base_url", base_url.rstrip("/"))
                 kwargs.setdefault("api_key", "x")
                 if "http_client" not in kwargs or kwargs["http_client"] is None:
@@ -173,12 +255,17 @@ def apply_adapter_patch(
     if PatchedAsyncOpenAI is not None:
         setattr(openai, "AsyncOpenAI", PatchedAsyncOpenAI)
 
-    # Patch resources
+    # Patch resources -------------------------------------------------------
+    # Resource-specific methods are monkeypatched so their HTTP layer uses the
+    # helpers above.  The replacements keep the public method signatures while
+    # quietly rewriting payloads and normalizing responses.
     from openai.resources.responses import Responses as _Responses
 
     _orig_resp_create = _Responses.create
 
     def _patched_resp_create(self, *args, **kwargs):
+        """Proxy ``Responses.create`` through the internal HTTP client."""
+
         model = kwargs.pop("model")
         input_ = kwargs.pop("input")
         stream = bool(kwargs.pop("stream", False))
@@ -195,6 +282,8 @@ def apply_adapter_patch(
         if stream:
 
             def _event_iterator():
+                """Yield streaming events using the internal HTTP endpoint."""
+
                 with http.stream("POST", path, json=payload) as r:
                     r.raise_for_status()
                     for line in r.iter_lines():
@@ -223,6 +312,8 @@ def apply_adapter_patch(
         _orig_chat_create = _ChatCompletions.create
 
         def _patched_chat_create(self, *args, **kwargs):
+            """Proxy ``ChatCompletions.create`` to the internal HTTP endpoint."""
+
             model = kwargs.pop("model")
             messages = kwargs.pop("messages")
             stream = bool(kwargs.pop("stream", False))

--- a/src/openai_monkey/config.py
+++ b/src/openai_monkey/config.py
@@ -1,3 +1,5 @@
+"""Configuration helpers for the OpenAI compatibility adapter."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,23 @@
+"""Regression tests ensuring public modules carry descriptive docstrings."""
+
+from importlib import import_module
+
+
+def test_adapter_docstrings_present(configure_adapter):
+    """The adapter exposes descriptive docstrings for modules and functions."""
+
+    module = configure_adapter()
+    assert module.__doc__, "openai_monkey module docstring should be defined"
+
+    adapter = import_module("openai_monkey.adapter")
+    assert adapter.__doc__, "adapter module docstring should describe the patch"
+    assert (
+        adapter.apply_adapter_patch.__doc__
+    ), "apply_adapter_patch must explain the monkeypatching process"
+
+
+def test_config_module_docstring_present():
+    """Configuration helpers are documented for discoverability."""
+
+    config = import_module("openai_monkey.config")
+    assert config.__doc__, "config module docstring should describe its purpose"


### PR DESCRIPTION
## Summary
- document the adapter, configuration, and package modules to clarify how the monkeypatch works
- add explanatory docstrings to helper functions that translate OpenAI requests
- cover documentation expectations with regression tests for module and function docstrings

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'respx')*


------
https://chatgpt.com/codex/tasks/task_e_68dfcbcfc8bc8325bfd7eba880bd65c9