### PR TITLE
Configure code quality tooling defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        name: black
+        language_version: python3
+        files: ^(src/openai_monkey|tests)/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+        files: ^(src/openai_monkey|tests)/
+      - id: ruff-format
+        files: ^(src/openai_monkey|tests)/
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+        pass_filenames: false
+        args: [
+          "--config-file",
+          "pyproject.toml",
+          "src/openai_monkey",
+          "tests",
+        ]

--- a/README.md
+++ b/README.md
@@ -78,3 +78,36 @@ Installing the package exposes two helper commands:
   ```
 
   Use `--site-packages=/custom/path` to target a specific environment.
+
+## Development workflow
+
+The repository ships with formatter, linter, and type-checker defaults that
+target `src/openai_monkey` and `tests`. Install the development dependencies and
+pre-commit hooks to keep your changes consistent:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+pip install pre-commit
+pre-commit install
+```
+
+Once configured, the hooks run the following tools automatically on staged
+files:
+
+| Tool | Command | Purpose |
+| --- | --- | --- |
+| Black | `black` | Enforces formatting. |
+| Ruff | `ruff format` and `ruff check --fix` | Applies import sorting and lint fixes. |
+| MyPy | `mypy src/openai_monkey tests` | Enforces strict static typing. |
+
+Run them manually across the full codebase before pushing:
+
+```bash
+ruff format src/openai_monkey tests
+ruff check src/openai_monkey tests
+black src/openai_monkey tests
+mypy
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,39 @@ test = [
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["openai_monkey*"]
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+include = "(src/openai_monkey|tests)/.*\\.pyi?$"
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+src = ["src/openai_monkey", "tests"]
+
+[tool.ruff.lint]
+select = [
+  "E",
+  "F",
+  "W",
+  "I",
+  "B",
+  "UP",
+  "SIM",
+  "S",
+  "A",
+]
+ignore = ["E203", "E501"]
+fixable = ["ALL"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.9"
+strict = true
+files = ["src/openai_monkey", "tests"]
+namespace_packages = true
+mypy_path = ["src"]


### PR DESCRIPTION
## Summary
- add project-wide Black, Ruff, and MyPy defaults for src/openai_monkey and tests
- wire the new tooling into a pre-commit configuration for local automation
- document the development workflow and commands in the README

## Testing
- pytest *(fails: missing optional dependency `respx` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcfbe61ac832595a9199d59caebcf